### PR TITLE
Add rudimentary device node

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ dist
 
 # VSCode
 *.code-workspace
+
+# deploy script
+update.sh
+.gitignore

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
 	"node-red": {
 		"nodes": {
 			"PLMConfig": "./dist/PLMConfig/PLMConfig.js",
-			"insteon-PLM": "./dist/insteonPLM/insteonPLM.js"
+			"insteon-PLM": "./dist/insteonPLM/insteonPLM.js",
+			"insteon-Device": "./dist/insteonDevice/insteonDevice.js"
 		}
 	},
 	"files": [

--- a/src/PLMConfig/PLMConfig.ts
+++ b/src/PLMConfig/PLMConfig.ts
@@ -31,6 +31,34 @@ export = function(RED: Red){
 
 		/* Setting up PLM */
 		setupPLM(this);
+		
+		/* Amateur Hour */
+		/* Keep track of all devices nodes which the user added to the flow
+		   When an insteon packet is received which matches the device node
+		   address, we route the packet to it so the node can update it's state
+		 */
+		this._devices = [];
+		
+		/* Fired when user deploys a device node */
+		this.addDevice = function(deviceNode){
+			/* Don't allow the user to add the same device multiple times. 
+			   One physical device = one device node. */
+			let duplicate = this._devices.filter(obj => obj.address.toString() === deviceNode.address.toString());
+			if(duplicate.length !== 0){
+				deviceNode.status({fill: 'red', shape: 'dot', text: 'Address already used by: '+ RED.nodes.getNode(duplicate[0].id).name});
+				return false;
+			}
+			
+			// this._devices.push({id: deviceNode.id, address: deviceNode.address});
+			this._devices.push(deviceNode);
+		}
+		
+		/* Fired when user deletes/changes a device node */
+		this.removeDevice = function(deviceNode){
+			this._devices = this._devices.filter(obj => obj.id !== deviceNode.id);
+		}
+
+		
 	});
 
 	/* Setting up server to get serial nodes */
@@ -90,6 +118,15 @@ function onError(node: PLMConfigNode, error: Error){
 	setTimeout(()=> setupPLM(node), reconnectTime);
 }
 function onPacket(node: PLMConfigNode, packet: Packets.Packet){
+	/* Amateur hour continued */
+	/* Packets emitted from the modem which have a from address tell us that the device state was updated.
+	   Route these packets to the Device node with the same address
+	*/
+	if(Array.isArray(packet.from)){
+		node._devices.filter(device => device.address.toString() === packet.from.toString())
+			.map(device => device.updateState(packet));
+	}
+	
 	/* Emitting Packet */
 	node.emit('packet', packet);
 }

--- a/src/insteonDevice/insteonDevice.html
+++ b/src/insteonDevice/insteonDevice.html
@@ -1,0 +1,69 @@
+<!-- Node Registration -->
+<script type="text/javascript">
+	RED.nodes.registerType('device',{
+		category: 'Insteon',
+		color: '#2e88c5',
+		align: 'left',
+		defaults: {
+			modem: { value:'', type:'PLMConfig' },
+			name: { value: '' },
+			address: {
+				value: '',
+				validate: function(v){
+					/* Check to see if this devie address was used in another node */
+					let devices = RED.nodes.filterNodes({type: "device"});
+					let duplicate = devices.filter(existing => existing.id !== this.id && existing.address === v.toLowerCase());
+					
+					if(duplicate.length > 0){
+						duplicate[0].dirty = true;
+						duplicate[0].highlighted = true;
+						RED.view.redraw();
+						
+						alert("`"+duplicate[0].name + "` is already using this address.");
+						return false;
+					}else{
+						/* Clear the red highlighted nodes */
+						devices.forEach(device => {
+							device.dirty = true;
+							device.highlighted = false;
+							RED.view.redraw();
+						});
+						return true;
+					}
+				}
+			}
+		},
+		inputs:0,
+		outputs:0,
+		icon: 'light.png',
+		label: function() {
+			return this.name || 'Device';
+		}
+	});
+</script>
+
+<!-- Node Configuration -->
+<script type="text/x-red" data-template-name="device">
+	<div class="form-row">
+		<label for="node-input-modem">Insteon Modem</label>
+		<input type="text" id="node-input-modem" placeholder="/dev/usb123">
+	</div>
+	<div class="form-row">
+		<label for="node-input-name"><i class="icon-tag"></i> Name</label>
+		<input type="text" id="node-input-name" placeholder="Name">
+	</div>
+	<div class="form-row">
+		<label for="node-input-address"><i class="icon-tag"></i>Address</label>
+		<input type="text" id="node-input-address" placeholder="aa.bb.cc" />
+	</div>
+</script>
+
+<!-- Help Panel -->
+<script type="text/x-red" data-help-name="device">
+	<h3>Info</h3>
+	<p>Represents one physical insteon device.</p>
+	
+	<p>Drag this node onto the pallet, assign it the insteon device ID and give it a name. </p>
+	
+	<p>The node will keep track of the current state of the physical device.</p>
+</script>

--- a/src/insteonDevice/insteonDevice.ts
+++ b/src/insteonDevice/insteonDevice.ts
@@ -1,0 +1,59 @@
+/* Exporting Node Function */
+export = function(RED: Red){		
+	/* Fired on every deploy */
+	// function insteonDevice(this: PLMNode, config: insteonPLMProps){
+	function insteonDevice(config){
+		/* Creating actual node */
+		RED.nodes.createNode(this, config);
+		
+		/* Turn the address string the user typed into the gui into an array of hex */
+		this.address = config.address.toLowerCase().split(".").map(octet => parseInt("0x"+octet,16));
+		
+		/* State is unknown until we get a packet */
+		this.state = {};
+		
+		/* Clear the status */
+		this.status({});
+
+		/* Checking if we don't have a modem */
+		if(!config.modem){
+			/* Updating status */
+			this.status({fill: 'red', shape: 'dot', text: 'No Modem Connected'});
+
+			/* Stopping execution */
+			return;
+		}
+
+		/* Retrieve the config node */
+		this.PLMConfigNode = RED.nodes.getNode(config.modem) as PLMConfigNode;
+		
+		/* Add this device to the config node's device list so that we can receive packets with the same address */
+		this.PLMConfigNode.addDevice(this);
+		
+		/* Clean up the config node's device list if this node is updated/deleted from the flow */
+		this.on('close', function(){
+			this.PLMConfigNode.removeDevice(this);
+		});
+		
+		/* Update our state based on the packet received
+		   Maybe should be renamed to packetHandler
+		*/
+		this.updateState = function(packet){
+			/* ToDo: Figure out how to interpret packet.type
+			   Figure out how to filter packets and interpret the values in order to update user friendly properties of the node
+			   e.g. device.on [true|false],
+			        device.level [0-100 int],
+			        device.motionDetected: [true|false],
+			        device.batteryLow: [true|false]
+			        etc
+			*/
+			
+			let debugMsg = (packet.cmd1 ? packet.cmd1.toString(16) : "") + ":" + (packet.cmd2 ? packet.cmd2.toString(16) : "");
+			this.status({fill: 'green', shape: 'dot', text: debugMsg});
+		}
+	}
+
+
+	/* Registering node type and a constructor*/
+	RED.nodes.registerType('device', insteonDevice);
+};


### PR DESCRIPTION
The device node doesn't do anything impressive yet, but you can drag it to the flow and assign a device address to it. All packets received by the PLM are routed to the device node.

Next step is to figure out how to interpret the packets into something user friendly.

I am using the config node, as this is really the PLM. 

I view the PLM node as more of a raw i/o node to use in case a Device Node, and future Subscribe/Command Nodes doesn't cover some unforeseen use case.

Vision:
User...
1. drags `device node` onto flow
2. configures the PLM port
3. types the device address into the config of the `device node`
4. The node should prompt them to link it to the plm if it isn't already linked. Confirming yes should automatically make a two way link with the plm so it can send and receive commands
5. The device node should then query for it's current state so that the node's properties are sync'd with it's real world state
5. The config panel of the `device node` show show all links
6. The config panel could allow the user to add more senders/receivers by choosing other configured device nodes from the drop down (thus creating a scene)

At the moment the `device node` has no inputs or outputs and cannot be duplicated (one physical device = one device node).

In order to conform to the Node-RED guidelines, I think there should be two more nodes, one for subscribing to device changes, another for sending it commands. These function very similar to mqtt in/out nodes, just without the mqtt server.

Another possibility would be to allow the `device node` to accept commands on input and the result of the command on output, while adding one other node to subscribe to device events. I haven't decide which is the more intuitive way to go.